### PR TITLE
Enable building on M1 (Apple Silicon) Macs

### DIFF
--- a/cmake/QuasselCompileSettings.cmake
+++ b/cmake/QuasselCompileSettings.cmake
@@ -108,7 +108,13 @@ endif()
 
 # Mac build stuff
 if (APPLE)
+  if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
+    set(CMAKE_OSX_ARCHITECTURES "arm64")
+    message(STATUS "Building for Apple Silicon Mac")
+  else()
     set(CMAKE_OSX_ARCHITECTURES "x86_64")
+    message(STATUS "Building for Intel Mac")
+  endif()
     add_compile_options(
         -mmacosx-version-min=10.9
         -stdlib=libc++

--- a/cmake/QuasselMacros.cmake
+++ b/cmake/QuasselMacros.cmake
@@ -135,7 +135,7 @@ function(quassel_add_executable _target)
     # Prepare bundle creation on macOS
     if(APPLE AND BUNDLE)
         set(BUNDLE_PATH "${CMAKE_INSTALL_PREFIX}/${BUNDLE_NAME}.app")
-        set(DMG_PATH "${CMAKE_INSTALL_PREFIX}/Quassel${ARG_COMPONENT}_MacOSX-x86_64_${QUASSEL_VERSION_STRING}.dmg")
+        set(DMG_PATH "${CMAKE_INSTALL_PREFIX}/Quassel${ARG_COMPONENT}_MacOSX-${CMAKE_OSX_ARCHITECTURES}_${QUASSEL_VERSION_STRING}.dmg")
 
         # Generate an appropriate Info.plist
         set(BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/Info_${ARG_COMPONENT}.plist")


### PR DESCRIPTION
Updated the compile settings to detect if the build is occurring on an Apple Silicon based Mac and setting the architecture appropriately.